### PR TITLE
Code Restructure

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,17 +1,21 @@
 provider "harbor" {
-  url = "http://localhost:30002"
-  username = ""
-  password = ""
+// Values should be set here, or in ENV
+//  url = "http://localhost:30002"
+//  username = ""
+//  password = ""
 }
+
 
 resource "harbor_project" "project" {
   name = "project"
 }
 
+
+
 resource "harbor_robot_account" "robot" {
   name = "robot$robot"
   project_id = harbor_project.project.id
-  robot_account_access {
+  access {
     resource = "image"
     action = "pull"
   }

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,7 @@ github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7
 github.com/hashicorp/terraform-config-inspect v0.0.0-20191212124732-c6ae6269b9d7/go.mod h1:p+ivJws3dpqbp1iP84+npOyAmTTOLMgCzrXd3GSdn/A=
 github.com/hashicorp/terraform-plugin-sdk v1.4.1 h1:REgN6WbySD6aIYdF6Uob3ic4eQkfh4NXSWU/casmgb4=
 github.com/hashicorp/terraform-plugin-sdk v1.4.1/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
+github.com/hashicorp/terraform-plugin-sdk v1.9.0 h1:WBHHIX/RgF6/lbfMCzx0qKl96BbQy3bexWFvDqt1bhE=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/provider/resource_harbor_project_test.go
+++ b/provider/resource_harbor_project_test.go
@@ -106,7 +106,7 @@ func testAccCheckHarborProjectDestroy() resource.TestCheckFunc {
 
 			group, _ := client.GetProject(id)
 			if group != nil {
-				return fmt.Errorf("group with id %s still exists", id)
+				return fmt.Errorf("project with id %s still exists", id)
 			}
 		}
 

--- a/provider/resource_harbor_robot_account.go
+++ b/provider/resource_harbor_robot_account.go
@@ -19,39 +19,53 @@ func resourceRobotAccount() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"project_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^robot\$.+`), "validation error: name must begin with 'robot$'"),
+				Description:  "ID of the project the robot account corosponds to in the form '/projects/${ID_NUMBER}'",
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^/projects/[0-9]+$`), "validation error: project_id should be of the form '/projects/${ID_NUMBER}'"),
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the robot account, beginning with 'robot$'",
+				ValidateFunc: validation.All(
+					validation.StringMatch(
+						regexp.MustCompile(`^robot\$[^~#$%]+`),
+						"validation error: name must begin with 'robot$' and must otherwise not include the special characters(~#$%)",
+					),
+					validation.StringLenBetween(1, 255),
+				),
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "A description of this robot account",
+				ValidateFunc: validation.StringLenBetween(1, 1024),
 			},
 			"disabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If true, this robot account is disabled.",
 			},
-			"robot_account_access": {
+			"access": {
 				Type:     schema.TypeSet,
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"action": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"push", "pull"}, false),
 						},
 						"resource": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"image", "helm-chart"}, false),
 						},
 					},
 				},
@@ -65,15 +79,8 @@ func resourceRobotAccount() *schema.Resource {
 	}
 }
 
-func resourceRobotAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*harbor.Client)
-
-	robot, err := client.GetRobotAccount(d.Id())
-	if err != nil {
-		return handleNotFoundError(err, d)
-	}
-
-	err = d.Set("name", robot.Name)
+func mapRobotAccountToData(d *schema.ResourceData, robot *harbor.RobotAccount) error {
+	err := d.Set("name", robot.Name)
 	if err != nil {
 		return err
 	}
@@ -85,23 +92,79 @@ func resourceRobotAccountRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
+}
+
+func mapRobotAccountPostRepToData(d *schema.ResourceData, robot *harbor.RobotAccountPostRep) error {
+	err := d.Set("token", robot.Token)
+	if err != nil {
+		return err
+	}
+	err = d.Set("name", robot.Name)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func mapDataToRobotAccountCreate(d *schema.ResourceData, robot *harbor.RobotAccountCreate) {
+	access := &[]harbor.RobotAccountAccess{}
+	mapDataToRobotAccountAccess(d, access)
+
+	robot.Name = strings.Replace(d.Get("name").(string), "robot$", "", 1)
+	robot.Description = d.Get("description").(string)
+	robot.Access = *access
+}
+
+func mapDataToRobotAccountAccess(d *schema.ResourceData, accessList *[]harbor.RobotAccountAccess) {
+	v, ok := d.GetOk("access")
+	if !ok {
+		return
+	}
+
+	projectID := d.Get("project_id").(string)
+	projectID = strings.Replace(projectID, "projects", "project", 1)
+
+	for _, dataAccess := range v.(*schema.Set).List() {
+		dataAccess := dataAccess.(map[string]interface{})
+		access := harbor.RobotAccountAccess{}
+		if dataAccess["resource"].(string) == "image" {
+			access.Action = dataAccess["action"].(string)
+			access.Resource = fmt.Sprintf("%s/repository", projectID)
+		} else if dataAccess["resource"].(string) == "helm-chart" {
+			if dataAccess["action"].(string) == "pull" {
+				access.Action = "read"
+				access.Resource = fmt.Sprintf("%s/helm-chart", projectID)
+			} else if dataAccess["action"].(string) == "push" {
+				access.Action = "create"
+				access.Resource = fmt.Sprintf("%s/helm-chart-version", projectID)
+			}
+		}
+		*accessList = append(*accessList, access)
+	}
+}
+
+func mapDataToRobotAccountUpdate(d *schema.ResourceData, robot *harbor.RobotAccountUpdate) {
+	robot.Disabled = d.Get("disabled").(bool)
+}
+
+func resourceRobotAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*harbor.Client)
+
+	robot, err := client.GetRobotAccount(d.Id())
+	if err != nil {
+		return handleNotFoundError(err, d)
+	}
+
+	return mapRobotAccountToData(d, robot)
 }
 
 func resourceRobotAccountCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*harbor.Client)
+	robot := &harbor.RobotAccountCreate{}
 
-	access := &[]harbor.RobotAccountAccess{}
-
-	if v, ok := d.GetOk("robot_account_access"); ok {
-		access = getRobotAccountAccessFromData(d.Get("project_id").(string), v.(*schema.Set).List())
-	}
-
-	robot := &harbor.RobotAccountCreate{
-		Name:        strings.Replace(d.Get("name").(string), "robot$", "", 1),
-		Description: d.Get("description").(string),
-		Access:      *access,
-	}
+	mapDataToRobotAccountCreate(d, robot)
 
 	body, location, err := client.NewRobotAccount(d.Get("project_id").(string), robot)
 	if err != nil {
@@ -109,11 +172,7 @@ func resourceRobotAccountCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.SetId(location)
-	err = d.Set("token", body.Token)
-	if err != nil {
-		return err
-	}
-	err = d.Set("name", body.Name)
+	err = mapRobotAccountPostRepToData(d, body)
 	if err != nil {
 		return err
 	}
@@ -121,40 +180,13 @@ func resourceRobotAccountCreate(d *schema.ResourceData, meta interface{}) error 
 	return resourceRobotAccountRead(d, meta)
 }
 
-func getRobotAccountAccessFromData(projectID string, data []interface{}) *[]harbor.RobotAccountAccess {
-	accessList := make([]harbor.RobotAccountAccess, 0, len(data))
-	resourcePrefix := strings.Replace(projectID, "projects", "project", 1)
-	for _, d := range data {
-		accessData := d.(map[string]interface{})
-		access := harbor.RobotAccountAccess{}
-		if accessData["resource"].(string) == "image" {
-			access.Action = accessData["action"].(string)
-			access.Resource = fmt.Sprintf("%s/repository", resourcePrefix)
-		} else if accessData["resource"].(string) == "helm-chart" {
-			if accessData["action"].(string) == "pull" {
-				access.Action = "read"
-				access.Resource = fmt.Sprintf("%s/helm-chart", resourcePrefix)
-			} else if accessData["action"].(string) == "push" {
-				access.Action = "create"
-				access.Resource = fmt.Sprintf("%s/helm-chart-version", resourcePrefix)
-			}
-		}
-		accessList = append(accessList, access)
-	}
-
-	return &accessList
-}
-
 func resourceRobotAccountUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*harbor.Client)
+	robot := &harbor.RobotAccountUpdate{}
 
-	robot := &harbor.RobotAccountUpdate{
-		Disabled: d.Get("disabled").(bool),
-	}
+	mapDataToRobotAccountUpdate(d, robot)
 
-	robotID := d.Id()
-
-	err := client.UpdateRobotAccount(robotID, robot)
+	err := client.UpdateRobotAccount(d.Id(), robot)
 	if err != nil {
 		return err
 	}
@@ -165,9 +197,7 @@ func resourceRobotAccountUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceRobotAccountDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*harbor.Client)
 
-	robotID := d.Id()
-
-	err := client.DeleteRobotAccount(robotID)
+	err := client.DeleteRobotAccount(d.Id())
 	if err != nil {
 		return err
 	}

--- a/provider/resource_harbor_robot_account_test.go
+++ b/provider/resource_harbor_robot_account_test.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/liatrio/terraform-provider-harbor/harbor"
+)
+
+func TestAccHarborRobotAccountBasic(t *testing.T) {
+	projectName := "terraform-" + acctest.RandString(10)
+	robotName := "robot$terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckHarborRobotAccountDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
+				Check:  testAccCheckHarborRobotAccountExists("harbor_robot_account.robot"),
+			},
+			//		{
+			//			ResourceName:        "keycloak_group.group",
+			//			ImportState:         true,
+			//			ImportStateVerify:   true,
+			//			ImportStateIdPrefix: realmName + "/",
+			//		},
+		},
+	})
+}
+
+func TestAccHarborRobotAccountUpdate(t *testing.T) {
+	projectName := "terraform-" + acctest.RandString(10)
+	robotName := "robot$terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckHarborRobotAccountDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
+				Check:  testAccCheckHarborRobotAccountExists("harbor_robot_account.robot"),
+			},
+			{
+				Config: testHarborRobotAccountBasic(projectName, robotName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHarborProjectExists("harbor_robot_account.robot"),
+					resource.TestCheckResourceAttr("harbor_robot_account.robot", "disabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testHarborRobotAccountBasic(projectName string, robotName string, disabled string) string {
+	return fmt.Sprintf(`
+resource "harbor_project" "project" {
+	name     = "%s"
+}
+
+resource "harbor_robot_account" "robot" {
+	name = "%s"
+	project_id = harbor_project.project.id
+	disabled = %s
+	access {
+		resource = "image"
+		action = "pull"
+	}
+}
+	`, projectName, robotName, disabled)
+}
+
+func testAccCheckHarborRobotAccountExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getRobotAccountFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func getRobotAccountFromState(s *terraform.State, resourceName string) (*harbor.RobotAccount, error) {
+	client := testAccProvider.Meta().(*harbor.Client)
+
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	id := rs.Primary.ID
+
+	project, err := client.GetRobotAccount(id)
+	if err != nil {
+		return nil, fmt.Errorf("error getting group with id %s: %s", id, err)
+	}
+
+	return project, nil
+}
+
+func testAccCheckHarborRobotAccountDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "harbor_robot_account" {
+				continue
+			}
+
+			id := rs.Primary.ID
+
+			client := testAccProvider.Meta().(*harbor.Client)
+
+			group, _ := client.GetRobotAccount(id)
+			if group != nil {
+				return fmt.Errorf("robot account with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}

--- a/scripts/runAccTests.sh
+++ b/scripts/runAccTests.sh
@@ -1,7 +1,16 @@
-read -p 'HarborURL: ' urlvar
-read -p 'Username: ' uservar
-read -sp 'Password: ' passvar
+if [ -z "$HARBOR_URL" ]; then
+  read -p 'HarborURL: ' HARBOR_URL
+fi
+if [ -z "$HARBOR_USERNAME" ]; then
+  read -p 'Username: ' HARBOR_USERNAME
+fi
+if [ -z "$HARBOR_PASSWORD" ]; then
+  read -sp 'Password: ' HARBOR_PASSWORD
+fi
 echo ''
 
+export HARBOR_URL
+export HARBOR_USERNAME
+export HARBOR_PASSWORD
 
-HARBOR_URL=$urlvar HARBOR_USERNAME=$uservar HARBOR_PASSWORD=$passvar TF_ACC=1 go test -timeout 20m $(go list ./... | grep -v 'vendor') -v
+TF_ACC=1 go test -timeout 20m $(go list ./... | grep -v 'vendor') -v


### PR DESCRIPTION
# Code Restructure 

## Schema Changes
- Rename `harbor_robot_account.robot_account_access` -> `harbor_robot_account.access`
- Change `harbor_project.public` from `TypeString` to `TypeBool`
- The default value of `harbor_project.public` has changed from `"true"` -> `false`
- `harbor_project.project_id` is no longer a property. `harbor_project.id` should be used instead.
- Changing `harbor_project.name` now forces the creation of a new project. This should have been true previously, as it is required by the Harbor API.

### Added Validation Functions
Validation functions check for parameters that Harbor REST calls will not support. These will now error at plan-time, as opposed to run-time. **These haven't changed the functionality of the variables, but they now validate the variables at an earlier time.**
- `harbor_project.name` must now be between 1-255 characters, and must contain only lowercase letters, numbers, and the characters `-_.`  The name must also start and end with a letter or number.
- `harbor_robot_account.name` must now be between 1-255 characters, must be prefixed by the string `robot$` and must otherwise not include the special characters `~#$%`
- `harbor_robot_account.project_id` must now be in the form of a resource location to the project, such as `'/projects/1'`. This is the same form given by the `harbor_project.id` variable.
- `harbor_robot_account.description` must now be between 1-1024 characters.
- `harbor_robot_account.access.resource` must now be one of the two strings `image` or `helm-chart`
- `harbor_robot_account.access.action` must now be one of the two strings `pull` or `push`

### Code Refactoring
All code converting between `schema.ResourceData` and Harbor API structs, is now contained within functions in the `provider` package. These functions take the form `mapDataTo{Resource}` where resource is the name of struct being mapped to. Alternatively the name should be `map{Resource}ToData` for the reverse mapping.

### Testing
Acceptance tests have been added for `resource_harbor_robot_account.go` these tests are contained in `resource_harbor_robot_account_test.go` and are adapted from the testing of the `project` resource. These tests only cover basic cases at the moment, and should be expanded in the future.
