### PR TITLE
Check for 404 when deleting resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 LOCALDIR?=$$(pwd)
 
+.PHONY: build install lint local testacc
+
 build:
 	go build -o terraform-provider-harbor
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Examples of how to use the provider can be found under the `examples/` directory
 To run automated linting on the codebase, run the command `make lint`
 To run the automated acceptance testing on the provider, run the command `make acctest`
 and provide the following data to the provided script.
-HarborURL: The base url of the Harbor instance to test agaist. i.e. `http://localhost:8080`
-Username: The username of the user to run acceptance tests as.
-Password: The passwrod of the user to run acceptance tests as.
+- HarborURL: The base url of the Harbor instance to test against. e.g. `http://localhost:8080`
+- Username: The username of the user to run acceptance tests as.
+- Password: The password of the user to run acceptance tests as.
 *Note:* Acceptance tests create real resources, and often cost money to run.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Harbor. This project includes scripts for setting up a local environment using
 docker-for-desktop's Kubernetes cluster, and Helm. If you'd prefer to use another instance
 of Harbor, that will also work, simply don't use the local environment scripts.
 
-If you would like to use the local environment, run the command `make local`
+If you would like to use the local environment, add the [Harbor Helm repo](https://github.com/goharbor/harbor-helm#add-helm-repository) and then run `make local`
 
 Your Harbor instance will be running on a random port that can be obtained by running
 the command `kubectl get service harbor`
@@ -35,7 +35,7 @@ the provider globally, under the development version `v0.0.0`.
 Examples of how to use the provider can be found under the `examples/` directory.
 
 To run automated linting on the codebase, run the command `make lint`
-To run the automated acceptance testing on the provider, run the command `make acctest`
+To run the automated acceptance testing on the provider, run the command `make testacc`
 and provide the following data to the provided script.
 - HarborURL: The base url of the Harbor instance to test against. e.g. `http://localhost:8080`
 - Username: The username of the user to run acceptance tests as.

--- a/provider/resource_harbor_project.go
+++ b/provider/resource_harbor_project.go
@@ -120,7 +120,7 @@ func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
 
 	repos, err := client.GetRepositories(projectID)
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	if len(repos) > 0 {
@@ -132,7 +132,7 @@ func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
 
 	charts, err := client.GetCharts(projectName)
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	if len(charts) > 0 {
@@ -144,7 +144,7 @@ func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
 
 	err = client.DeleteProject(d.Id())
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	d.SetId("")

--- a/provider/resource_harbor_project_test.go
+++ b/provider/resource_harbor_project_test.go
@@ -22,12 +22,6 @@ func TestAccHarborProjectBasic(t *testing.T) {
 				Config: testHarborProjectBasic(projectName, "true"),
 				Check:  testAccCheckHarborProjectExists("harbor_project.project"),
 			},
-			//		{
-			//			ResourceName:        "keycloak_group.group",
-			//			ImportState:         true,
-			//			ImportStateVerify:   true,
-			//			ImportStateIdPrefix: realmName + "/",
-			//		},
 		},
 	})
 }
@@ -87,7 +81,7 @@ func getProjectFromState(s *terraform.State, resourceName string) (*harbor.Proje
 
 	project, err := client.GetProject(id)
 	if err != nil {
-		return nil, fmt.Errorf("error getting group with id %s: %s", id, err)
+		return nil, fmt.Errorf("error getting project with id %s: %s", id, err)
 	}
 
 	return project, nil
@@ -104,8 +98,8 @@ func testAccCheckHarborProjectDestroy() resource.TestCheckFunc {
 
 			client := testAccProvider.Meta().(*harbor.Client)
 
-			group, _ := client.GetProject(id)
-			if group != nil {
+			project, _ := client.GetProject(id)
+			if project != nil {
 				return fmt.Errorf("project with id %s still exists", id)
 			}
 		}

--- a/provider/resource_harbor_robot_account.go
+++ b/provider/resource_harbor_robot_account.go
@@ -22,7 +22,7 @@ func resourceRobotAccount() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				Description:  "ID of the project the robot account corosponds to in the form '/projects/${ID_NUMBER}'",
+				Description:  "ID of the project the robot account corresponds to in the form '/projects/${ID_NUMBER}'",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^/projects/[0-9]+$`), "validation error: project_id should be of the form '/projects/${ID_NUMBER}'"),
 			},
 			"name": {
@@ -199,7 +199,7 @@ func resourceRobotAccountDelete(d *schema.ResourceData, meta interface{}) error 
 
 	err := client.DeleteRobotAccount(d.Id())
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d)
 	}
 
 	d.SetId("")


### PR DESCRIPTION
Most of the time this would be caught when Terraform refreshes state, since the reads for the project and robot accounts already handled manual deletions. However, it could still happen if the deletion occurs after refreshing state, which is easy to do when running TF manually.