### PR TITLE
Update acceptence testing

### DIFF
--- a/harbor/utils.go
+++ b/harbor/utils.go
@@ -1,0 +1,12 @@
+package harbor
+
+func (client *Client) GetResource(id string) (interface{}, error) {
+	resource := make(map[string]interface{})
+
+	err := client.get(id, &resource, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}

--- a/provider/resource_harbor_project_test.go
+++ b/provider/resource_harbor_project_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/liatrio/terraform-provider-harbor/harbor"
 )
 
-func TestAccHarborProject_Basic(t *testing.T) {
+func TestAccHarborProjectBasic(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -25,7 +25,7 @@ func TestAccHarborProject_Basic(t *testing.T) {
 	})
 }
 
-func TestAccHarborProject_Update(t *testing.T) {
+func TestAccHarborProjectUpdate(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
@@ -48,7 +48,7 @@ func TestAccHarborProject_Update(t *testing.T) {
 	})
 }
 
-func TestAccHarborProject_CreateAfterManualDestroy(t *testing.T) {
+func TestAccHarborProjectCreateAfterManualDestroy(t *testing.T) {
 	var projectID string
 
 	projectName := "terraform-" + acctest.RandString(10)
@@ -62,7 +62,7 @@ func TestAccHarborProject_CreateAfterManualDestroy(t *testing.T) {
 				Config: testHarborProjectBasic(projectName, "false"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceExists("harbor_project.project"),
-					testCheckGetResourceId("harbor_project.project", &projectID),
+					testCheckGetResourceID("harbor_project.project", &projectID),
 				),
 			},
 			{

--- a/provider/resource_harbor_project_test.go
+++ b/provider/resource_harbor_project_test.go
@@ -6,44 +6,76 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/liatrio/terraform-provider-harbor/harbor"
 )
 
-func TestAccHarborProjectBasic(t *testing.T) {
+func TestAccHarborProject_Basic(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckHarborProjectDestroy(),
+		CheckDestroy: testCheckResourceDestroy("harbor_project"),
 		Steps: []resource.TestStep{
 			{
-				Config: testHarborProjectBasic(projectName, "true"),
-				Check:  testAccCheckHarborProjectExists("harbor_project.project"),
+				Config: testHarborProjectBasic(projectName, "false"),
+				Check:  testCheckResourceExists("harbor_project.project"),
 			},
 		},
 	})
 }
 
-func TestAccHarborProjectUpdate(t *testing.T) {
+func TestAccHarborProject_Update(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckHarborProjectDestroy(),
+		CheckDestroy: testCheckResourceDestroy("harbor_project"),
 		Steps: []resource.TestStep{
 			{
-				Config: testHarborProjectBasic(projectName, "true"),
-				Check:  testAccCheckHarborProjectExists("harbor_project.project"),
+				Config: testHarborProjectBasic(projectName, "false"),
+				Check:  testCheckResourceExists("harbor_project.project"),
 			},
+			{
+				Config: testHarborProjectBasic(projectName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceExists("harbor_project.project"),
+					resource.TestCheckResourceAttr("harbor_project.project", "public", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHarborProject_CreateAfterManualDestroy(t *testing.T) {
+	var projectID string
+
+	projectName := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testCheckResourceDestroy("harbor_project"),
+		Steps: []resource.TestStep{
 			{
 				Config: testHarborProjectBasic(projectName, "false"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHarborProjectExists("harbor_project.project"),
-					resource.TestCheckResourceAttr("harbor_project.project", "public", "false"),
+					testCheckResourceExists("harbor_project.project"),
+					testCheckGetResourceId("harbor_project.project", &projectID),
 				),
+			},
+			{
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*harbor.Client)
+
+					err := client.DeleteProject(projectID)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testHarborProjectBasic(projectName, "true"),
+				Check:  testCheckResourceExists("harbor_project.project"),
 			},
 		},
 	})
@@ -56,54 +88,4 @@ resource "harbor_project" "project" {
 	public   = "%s"
 }
 	`, projectName, public)
-}
-
-func testAccCheckHarborProjectExists(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, err := getProjectFromState(s, resourceName)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-}
-
-func getProjectFromState(s *terraform.State, resourceName string) (*harbor.Project, error) {
-	client := testAccProvider.Meta().(*harbor.Client)
-
-	rs, ok := s.RootModule().Resources[resourceName]
-	if !ok {
-		return nil, fmt.Errorf("resource not found: %s", resourceName)
-	}
-
-	id := rs.Primary.ID
-
-	project, err := client.GetProject(id)
-	if err != nil {
-		return nil, fmt.Errorf("error getting project with id %s: %s", id, err)
-	}
-
-	return project, nil
-}
-
-func testAccCheckHarborProjectDestroy() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "harbor_project" {
-				continue
-			}
-
-			id := rs.Primary.ID
-
-			client := testAccProvider.Meta().(*harbor.Client)
-
-			project, _ := client.GetProject(id)
-			if project != nil {
-				return fmt.Errorf("project with id %s still exists", id)
-			}
-		}
-
-		return nil
-	}
 }

--- a/provider/resource_harbor_robot_account.go
+++ b/provider/resource_harbor_robot_account.go
@@ -177,7 +177,7 @@ func resourceRobotAccountCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	return resourceRobotAccountRead(d, meta)
+	return resourceRobotAccountUpdate(d, meta)
 }
 
 func resourceRobotAccountUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/provider/resource_harbor_robot_account_test.go
+++ b/provider/resource_harbor_robot_account_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/liatrio/terraform-provider-harbor/harbor"
 )
 
-func TestAccHarborRobotAccount_Basic(t *testing.T) {
+func TestAccHarborRobotAccountBasic(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 	robotName := "robot$terraform-" + acctest.RandString(10)
 	resourceName := "harbor_robot_account.robot"
@@ -30,7 +30,7 @@ func TestAccHarborRobotAccount_Basic(t *testing.T) {
 	})
 }
 
-func TestAccHarborRobotAccount_Full(t *testing.T) {
+func TestAccHarborRobotAccountFull(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 	robotName := "robot$terraform-" + acctest.RandString(10)
 	resourceName := "harbor_robot_account.robot"
@@ -59,7 +59,7 @@ func TestAccHarborRobotAccount_Full(t *testing.T) {
 	})
 }
 
-func TestAccHarborRobotAccount_Update(t *testing.T) {
+func TestAccHarborRobotAccountUpdate(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 	robotName := "robot$terraform-" + acctest.RandString(10)
 	resourceName := "harbor_robot_account.robot"
@@ -84,8 +84,8 @@ func TestAccHarborRobotAccount_Update(t *testing.T) {
 	})
 }
 
-func TestAccHarborRobotAccount_CreateAfterManualDestroy(t *testing.T) {
-	var robotId string
+func TestAccHarborRobotAccountCreateAfterManualDestroy(t *testing.T) {
+	var robotID string
 
 	projectName := "terraform-" + acctest.RandString(10)
 	robotName := "robot$terraform-" + acctest.RandString(10)
@@ -100,14 +100,14 @@ func TestAccHarborRobotAccount_CreateAfterManualDestroy(t *testing.T) {
 				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckResourceExists(resourceName),
-					testCheckGetResourceId(resourceName, &robotId),
+					testCheckGetResourceID(resourceName, &robotID),
 				),
 			},
 			{
 				PreConfig: func() {
 					client := testAccProvider.Meta().(*harbor.Client)
 
-					err := client.DeleteRobotAccount(robotId)
+					err := client.DeleteRobotAccount(robotID)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -119,7 +119,7 @@ func TestAccHarborRobotAccount_CreateAfterManualDestroy(t *testing.T) {
 	})
 }
 
-func testCreateHarborRobotAccount_Basic(projectName string, robotName string, disabled string) string {
+func testCreateHarborRobotAccountBasic(projectName string, robotName string, disabled string) string {
 	return fmt.Sprintf(`
 resource "harbor_project" "project" {
 	name     = "%s"
@@ -137,7 +137,7 @@ resource "harbor_robot_account" "robot" {
 	`, projectName, robotName, disabled)
 }
 
-func testCreateHarborRobotAccount_Full(projectName string, robotName string, description string, disabled string) string {
+func testCreateHarborRobotAccountFull(projectName string, robotName string, description string, disabled string) string {
 	return fmt.Sprintf(`
 resource "harbor_project" "project" {
 	name     = "%s"

--- a/provider/resource_harbor_robot_account_test.go
+++ b/provider/resource_harbor_robot_account_test.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/liatrio/terraform-provider-harbor/harbor"
 )
 
-func TestAccHarborRobotAccountBasic(t *testing.T) {
+func TestAccHarborRobotAccount_Basic(t *testing.T) {
 	projectName := "terraform-" + acctest.RandString(10)
 	robotName := "robot$terraform-" + acctest.RandString(10)
+	resourceName := "harbor_robot_account.robot"
 
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
@@ -18,38 +20,106 @@ func TestAccHarborRobotAccountBasic(t *testing.T) {
 		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
-				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
-				Check:  testCheckResourceExists("harbor_robot_account.robot"),
-			},
-		},
-	})
-}
-
-func TestAccHarborRobotAccountUpdate(t *testing.T) {
-	projectName := "terraform-" + acctest.RandString(10)
-	robotName := "robot$terraform-" + acctest.RandString(10)
-
-	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
-		Steps: []resource.TestStep{
-			{
-				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
-				Check:  testCheckResourceExists("harbor_robot_account.robot"),
-			},
-			{
-				Config: testHarborRobotAccountBasic(projectName, robotName, "true"),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckResourceExists("harbor_robot_account.robot"),
-					resource.TestCheckResourceAttr("harbor_robot_account.robot", "disabled", "true"),
+				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckResourceExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
 				),
 			},
 		},
 	})
 }
 
-func testHarborRobotAccountBasic(projectName string, robotName string, disabled string) string {
+func TestAccHarborRobotAccount_Full(t *testing.T) {
+	projectName := "terraform-" + acctest.RandString(10)
+	robotName := "robot$terraform-" + acctest.RandString(10)
+	resourceName := "harbor_robot_account.robot"
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateHarborRobotAccount_Full(
+					projectName,
+					robotName,
+					"A Test Robot Account",
+					"true",
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", robotName),
+					resource.TestCheckResourceAttr(resourceName, "description", "A Test Robot Account"),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHarborRobotAccount_Update(t *testing.T) {
+	projectName := "terraform-" + acctest.RandString(10)
+	robotName := "robot$terraform-" + acctest.RandString(10)
+	resourceName := "harbor_robot_account.robot"
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Check:  testCheckResourceExists(resourceName),
+			},
+			{
+				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHarborRobotAccount_CreateAfterManualDestroy(t *testing.T) {
+	var robotId string
+
+	projectName := "terraform-" + acctest.RandString(10)
+	robotName := "robot$terraform-" + acctest.RandString(10)
+	resourceName := "harbor_robot_account.robot"
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testCheckResourceExists(resourceName),
+					testCheckGetResourceId(resourceName, &robotId),
+				),
+			},
+			{
+				PreConfig: func() {
+					client := testAccProvider.Meta().(*harbor.Client)
+
+					err := client.DeleteRobotAccount(robotId)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "true"),
+				Check:  testCheckResourceExists(resourceName),
+			},
+		},
+	})
+}
+
+func testCreateHarborRobotAccount_Basic(projectName string, robotName string, disabled string) string {
 	return fmt.Sprintf(`
 resource "harbor_project" "project" {
 	name     = "%s"
@@ -65,4 +135,36 @@ resource "harbor_robot_account" "robot" {
 	}
 }
 	`, projectName, robotName, disabled)
+}
+
+func testCreateHarborRobotAccount_Full(projectName string, robotName string, description string, disabled string) string {
+	return fmt.Sprintf(`
+resource "harbor_project" "project" {
+	name     = "%s"
+}
+
+resource "harbor_robot_account" "robot" {
+	project_id = harbor_project.project.id
+
+	name = "%s"
+	description = "%s"
+	disabled = %s
+	access {
+		resource = "image"
+		action = "pull"
+	}
+	access {
+		resource = "image"
+		action = "push"
+	}
+	access {
+		resource = "helm-chart"
+		action = "pull"
+	}
+	access {
+		resource = "helm-chart"
+		action = "push"
+	}
+}
+	`, projectName, robotName, description, disabled)
 }

--- a/provider/resource_harbor_robot_account_test.go
+++ b/provider/resource_harbor_robot_account_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/liatrio/terraform-provider-harbor/harbor"
 )
 
 func TestAccHarborRobotAccountBasic(t *testing.T) {
@@ -17,18 +15,12 @@ func TestAccHarborRobotAccountBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckHarborRobotAccountDestroy(),
+		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
 				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
-				Check:  testAccCheckHarborRobotAccountExists("harbor_robot_account.robot"),
+				Check:  testCheckResourceExists("harbor_robot_account.robot"),
 			},
-			//		{
-			//			ResourceName:        "keycloak_group.group",
-			//			ImportState:         true,
-			//			ImportStateVerify:   true,
-			//			ImportStateIdPrefix: realmName + "/",
-			//		},
 		},
 	})
 }
@@ -40,16 +32,16 @@ func TestAccHarborRobotAccountUpdate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckHarborRobotAccountDestroy(),
+		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
 				Config: testHarborRobotAccountBasic(projectName, robotName, "false"),
-				Check:  testAccCheckHarborRobotAccountExists("harbor_robot_account.robot"),
+				Check:  testCheckResourceExists("harbor_robot_account.robot"),
 			},
 			{
 				Config: testHarborRobotAccountBasic(projectName, robotName, "true"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHarborProjectExists("harbor_robot_account.robot"),
+					testCheckResourceExists("harbor_robot_account.robot"),
 					resource.TestCheckResourceAttr("harbor_robot_account.robot", "disabled", "true"),
 				),
 			},
@@ -73,54 +65,4 @@ resource "harbor_robot_account" "robot" {
 	}
 }
 	`, projectName, robotName, disabled)
-}
-
-func testAccCheckHarborRobotAccountExists(resourceName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, err := getRobotAccountFromState(s, resourceName)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-}
-
-func getRobotAccountFromState(s *terraform.State, resourceName string) (*harbor.RobotAccount, error) {
-	client := testAccProvider.Meta().(*harbor.Client)
-
-	rs, ok := s.RootModule().Resources[resourceName]
-	if !ok {
-		return nil, fmt.Errorf("resource not found: %s", resourceName)
-	}
-
-	id := rs.Primary.ID
-
-	project, err := client.GetRobotAccount(id)
-	if err != nil {
-		return nil, fmt.Errorf("error getting group with id %s: %s", id, err)
-	}
-
-	return project, nil
-}
-
-func testAccCheckHarborRobotAccountDestroy() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "harbor_robot_account" {
-				continue
-			}
-
-			id := rs.Primary.ID
-
-			client := testAccProvider.Meta().(*harbor.Client)
-
-			group, _ := client.GetRobotAccount(id)
-			if group != nil {
-				return fmt.Errorf("robot account with id %s still exists", id)
-			}
-		}
-
-		return nil
-	}
 }

--- a/provider/resource_harbor_robot_account_test.go
+++ b/provider/resource_harbor_robot_account_test.go
@@ -20,7 +20,7 @@ func TestAccHarborRobotAccountBasic(t *testing.T) {
 		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Config: testCreateHarborRobotAccountBasic(projectName, robotName, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckResourceExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
@@ -41,7 +41,7 @@ func TestAccHarborRobotAccountFull(t *testing.T) {
 		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateHarborRobotAccount_Full(
+				Config: testCreateHarborRobotAccountFull(
 					projectName,
 					robotName,
 					"A Test Robot Account",
@@ -70,11 +70,11 @@ func TestAccHarborRobotAccountUpdate(t *testing.T) {
 		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Config: testCreateHarborRobotAccountBasic(projectName, robotName, "false"),
 				Check:  testCheckResourceExists(resourceName),
 			},
 			{
-				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "true"),
+				Config: testCreateHarborRobotAccountBasic(projectName, robotName, "true"),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckResourceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
@@ -97,7 +97,7 @@ func TestAccHarborRobotAccountCreateAfterManualDestroy(t *testing.T) {
 		CheckDestroy: testCheckResourceDestroy("harbor_robot_account"),
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "false"),
+				Config: testCreateHarborRobotAccountBasic(projectName, robotName, "false"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testCheckResourceExists(resourceName),
 					testCheckGetResourceID(resourceName, &robotID),
@@ -112,7 +112,7 @@ func TestAccHarborRobotAccountCreateAfterManualDestroy(t *testing.T) {
 						t.Fatal(err)
 					}
 				},
-				Config: testCreateHarborRobotAccount_Basic(projectName, robotName, "true"),
+				Config: testCreateHarborRobotAccountBasic(projectName, robotName, "true"),
 				Check:  testCheckResourceExists(resourceName),
 			},
 		},

--- a/provider/utils_test.go
+++ b/provider/utils_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/liatrio/terraform-provider-harbor/harbor"
+)
+
+func testCheckResourceExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*harbor.Client)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		resourceId := rs.Primary.ID
+
+		_, err := client.GetResource(resourceId)
+		if err != nil {
+			return fmt.Errorf("error getting project with id %s: %s", resourceId, err)
+		}
+
+		return nil
+	}
+}
+
+func testCheckGetResourceId(resourceName string, resourceId *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		*resourceId = rs.Primary.ID
+
+		return nil
+	}
+}
+
+func testCheckResourceDestroy(resourceType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+
+			id := rs.Primary.ID
+
+			client := testAccProvider.Meta().(*harbor.Client)
+
+			resource, _ := client.GetResource(id)
+			if resource != nil {
+				return fmt.Errorf("project with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}

--- a/provider/utils_test.go
+++ b/provider/utils_test.go
@@ -17,25 +17,25 @@ func testCheckResourceExists(resourceName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		resourceId := rs.Primary.ID
+		resourceID := rs.Primary.ID
 
-		_, err := client.GetResource(resourceId)
+		_, err := client.GetResource(resourceID)
 		if err != nil {
-			return fmt.Errorf("error getting project with id %s: %s", resourceId, err)
+			return fmt.Errorf("error getting project with id %s: %s", resourceID, err)
 		}
 
 		return nil
 	}
 }
 
-func testCheckGetResourceId(resourceName string, resourceId *string) resource.TestCheckFunc {
+func testCheckGetResourceID(resourceName string, resourceID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		*resourceId = rs.Primary.ID
+		*resourceID = rs.Primary.ID
 
 		return nil
 	}

--- a/scripts/helmRelease.sh
+++ b/scripts/helmRelease.sh
@@ -1,6 +1,6 @@
 helm status terraform-provider-harbor-acctest 2>/dev/null
 if [ $? == 1 ]; then
-  helm install terraform-provider-harbor-acctest harbor/harbor --set expose.type=nodePort,expose.tls.enabled=false
+  helm install terraform-provider-harbor-acctest harbor/harbor --set expose.type=nodePort,expose.tls.enabled=false --version "1.3.4"
 fi
 
 echo


### PR DESCRIPTION
Updates structure of acceptance tests to make code reusable, and to remove sections of code that were previously repeated.
Adds several unit tests, covering more complex creation tasks, and validating provider's recovery in the case of manual changes to Harbor.
Locks local testing helm chart version to 1.3.4 (Harbor OSS version: 1.10.4)
Fixes bug found by new tests. Previously when setting the harbor_robot_account resource's disabled flag, the property could not be set to true on initial creation. This PR correct that mistake.