### PR TITLE
Automatically Refresh Expired Robot Accounts

### DIFF
--- a/provider/resource_harbor_robot_account.go
+++ b/provider/resource_harbor_robot_account.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"time"
 	"regexp"
 	"strings"
 
@@ -155,6 +156,14 @@ func resourceRobotAccountRead(d *schema.ResourceData, meta interface{}) error {
 	robot, err := client.GetRobotAccount(d.Id())
 	if err != nil {
 		return handleNotFoundError(err, d)
+	}
+	if int(time.Now().Unix()) >= robot.ExpiresAt {
+		err = client.DeleteRobotAccount(d.Id())
+		if err != nil {
+			return err
+		}
+		d.SetId("")
+		return nil
 	}
 
 	return mapRobotAccountToData(d, robot)


### PR DESCRIPTION
# Auto Refresh Expired Robot Accounts

This PR checks expiration on the read of a robot account. If the account token has expired, the robot account is automatically deleted from Harbor, and removed from state so that Terraform can recreate the resource.