### PR TITLE
Strip project name from repository upon delete

### DIFF
--- a/harbor/repository.go
+++ b/harbor/repository.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -29,7 +30,7 @@ func (client *Client) GetRepositories(projectName string) ([]*Repository, error)
 }
 
 func (client *Client) DeleteRepository(projectName string, repoName string) error {
-	repo := repoName[len(projectName)+1:] // repoName has the format projectName/repo, strip the projectName/ prefix
+	repo := strings.TrimPrefix(repoName, projectName+"/")
 
 	return client.delete(APIURLVersion2, fmt.Sprintf("/projects/%s/repositories/%s", projectName, repo), nil)
 }

--- a/harbor/repository.go
+++ b/harbor/repository.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -29,7 +30,9 @@ func (client *Client) GetRepositories(projectName string) ([]*Repository, error)
 }
 
 func (client *Client) DeleteRepository(projectName string, repoName string) error {
-	return client.delete(APIURLVersion2, fmt.Sprintf("/projects/%s/repositories/%s", projectName, repoName), nil)
+	repo := strings.TrimPrefix(repoName, projectName)
+
+	return client.delete(APIURLVersion2, fmt.Sprintf("/projects/%s/repositories/%s", projectName, repo), nil)
 }
 
 func (client *Client) DeleteRepositories(projectName string, repos []*Repository) error {

--- a/harbor/repository.go
+++ b/harbor/repository.go
@@ -2,7 +2,6 @@ package harbor
 
 import (
 	"fmt"
-	"strings"
 	"time"
 )
 
@@ -30,7 +29,7 @@ func (client *Client) GetRepositories(projectName string) ([]*Repository, error)
 }
 
 func (client *Client) DeleteRepository(projectName string, repoName string) error {
-	repo := strings.TrimPrefix(repoName, projectName)
+	repo := repoName[len(projectName)+1:] // repoName has the format projectName/repo, strip the projectName/ prefix
 
 	return client.delete(APIURLVersion2, fmt.Sprintf("/projects/%s/repositories/%s", projectName, repo), nil)
 }


### PR DESCRIPTION
We stumbled onto this while working on the Rode demo. When tearing down a Harbor project, the provider first removes all repositories and charts. In the Harbor v1 API, that delete call for a repository `alpine` in a project `local` looks like:

```
curl -X DELETE "https://harbor.localhost/api/repositories/local%2Falpine"
```

with the project name prefixed to the repository name.

In the v2 Harbor API, the endpoint is slightly different:

```
curl -X DELETE "https://harbor.localhost/api/v2.0/projects/local/repositories/alpine
```

Unfortunately, the call to get the repositories still returns the repository name prefixed with the project name, which can't be passed into the delete endpoint without additional changes. Otherwise, the call will return a 404, because there is no repository with the project prefix, which is what we saw in the demo:

```
Error: error sending DELETE request to /api/v2.0/projects/rode-demo/repositories/rode-demo/rode-demo-node-app: 404 Not Found
```

To fix this, we opted to just strip the project prefix from the repo name, which is what the [Harbor UI does](https://github.com/goharbor/harbor/blob/e714a8eacc5edce218ca96e6a458413f71badf0c/src/portal/src/app/base/project/repository/repository-gridview.component.ts#L236) as far as we could tell. 
